### PR TITLE
mrc-4177 allow passing of dependencies to task queue

### DIFF
--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -18,7 +18,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - uses: r-lib/actions/setup-r@v1
+      - uses: r-lib/actions/setup-r@v2
 
       - uses: r-lib/actions/setup-pandoc@v1
 

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -23,7 +23,7 @@ Suggests:
     testthat,
     thor
 Remotes:
-    mrc-ide/context@mrc-4177
+    mrc-ide/context
 RoxygenNote: 7.2.3
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: queuer
 Title: Queue Tasks
-Version: 0.4.0
+Version: 0.5.0
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("Imperial College of Science, Technology and Medicine",
@@ -13,7 +13,7 @@ Depends:
     R (>= 3.2.2)
 Imports:
     R6,
-    context (>= 0.4.0),
+    context (>= 0.5.0),
     ids,
     lazyeval,
     progress (>= 1.1.1)
@@ -23,7 +23,7 @@ Suggests:
     testthat,
     thor
 Remotes:
-    mrc-ide/context
+    mrc-ide/context@mrc-4177
 RoxygenNote: 7.2.3
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)

--- a/R/bulk.R
+++ b/R/bulk.R
@@ -24,6 +24,7 @@ enqueue_bulk <- function(obj, private, X, FUN, ..., do_call = TRUE,
                          timeout = 0, time_poll = 1, progress = NULL,
                          name = NULL, use_names = TRUE,
                          overwrite = FALSE, depends_on = NULL) {
+
   obj <- enqueue_bulk_submit(obj, private, X, FUN, ..., do_call = do_call,
                              envir = envir, progress = progress, name = name,
                              use_names = use_names, overwrite = overwrite, depends_on = depends_on)

--- a/R/bulk.R
+++ b/R/bulk.R
@@ -23,10 +23,10 @@ enqueue_bulk <- function(obj, private, X, FUN, ..., do_call = TRUE,
                          envir = parent.frame(),
                          timeout = 0, time_poll = 1, progress = NULL,
                          name = NULL, use_names = TRUE,
-                         overwrite = FALSE) {
+                         overwrite = FALSE, depends_on = NULL) {
   obj <- enqueue_bulk_submit(obj, private, X, FUN, ..., do_call = do_call,
                              envir = envir, progress = progress, name = name,
-                             use_names = use_names, overwrite = overwrite)
+                             use_names = use_names, overwrite = overwrite, depends_on = depends_on)
   if (timeout > 0) {
     ## TODO: this is possibly going to change as interrupt changes in
     ## current R-devel (as of 3.3.x)
@@ -41,7 +41,7 @@ enqueue_bulk_submit <- function(obj, private, X, FUN, ..., DOTS = NULL,
                                 do_call = FALSE,
                                 envir = parent.frame(), progress = NULL,
                                 name = NULL, use_names = TRUE,
-                                overwrite = FALSE) {
+                                overwrite = FALSE, depends_on = NULL) {
   ## TODO: If I push this to *only* be a method, then the assertion is
   ## not needed.
   if (!inherits(obj, "queue_base")) {
@@ -61,7 +61,7 @@ enqueue_bulk_submit <- function(obj, private, X, FUN, ..., DOTS = NULL,
     DOTS <- lapply(lazyeval::lazy_dots(...), "[[", "expr")
   }
   ids <- context::bulk_task_save(X, FUN, obj$context, DOTS,
-                                 do_call, use_names, envir)
+                                 do_call, use_names, envir, depends_on)
 
   message(sprintf("submitting %s tasks", length(ids)))
   private$submit_or_delete(ids, names(ids))

--- a/R/bulk.R
+++ b/R/bulk.R
@@ -1,14 +1,14 @@
 qlapply <- function(obj, private, X, FUN, ...,
                     envir = parent.frame(),
                     timeout = 0, time_poll = 1, progress = NULL,
-                    name = NULL, overwrite = FALSE) {
+                    name = NULL, overwrite = FALSE, depends_on = NULL) {
   ## TODO: The dots here are going to cause grief at some point.  I
   ## may need a more robust way of passing additional arguments in,
   ## but not sure what that looks like...
   enqueue_bulk(obj, private, X, FUN, ..., do_call = FALSE,
                timeout = timeout, time_poll = time_poll,
                progress = progress, name = name,
-               envir = envir, overwrite = overwrite)
+               envir = envir, overwrite = overwrite, depends_on = depends_on)
 }
 
 ## A downside of the current treatment of dots is there are quite a

--- a/R/queue_base.R
+++ b/R/queue_base.R
@@ -250,7 +250,9 @@ queue_base <- R6::R6Class(
     ##'
     ##' @param name Optional name for a created bundle
     ##'
-    ##' @param depends_on Optional vector of task ids to depend on
+    ##' @param depends_on Optional task ids to depend on.
+    ##'   Should be a list of lists with an element per task.
+    ##'   For example, list(list("abcde", "12345"), list(), list("12345"))
     ##'
     ##' @param overwrite Logical, indicating if we should overwrite any
     ##'   bundle that exists with name `name`.

--- a/R/queue_base.R
+++ b/R/queue_base.R
@@ -364,7 +364,8 @@ queue_base <- R6::R6Class(
     ##'
     ##' @param names Optional vector of names of tasks
     ##'
-    ##' @param depends_on Optional vector of task ids to depend on, named by task id
+    ##' @param depends_on Optional named list of task ids to vectors of
+    ##'    dependencies, e.g. list("t3" = c("t", "t1"), "t4" = "t)
     submit = function(task_ids, names = NULL, depends_on = NULL) {
     },
 

--- a/R/queue_base.R
+++ b/R/queue_base.R
@@ -202,7 +202,7 @@ queue_base <- R6::R6Class(
     ##'
     ##' @param name Optional name for the task
     ##'
-    ##' @param names Optional vector of task dependencies
+    ##' @param depends_on Optional vector of task dependencies
     ##'
     enqueue_ = function(expr, envir = parent.frame(), submit = TRUE,
                         name = NULL, depends_on = NULL) {

--- a/R/queue_base.R
+++ b/R/queue_base.R
@@ -250,9 +250,8 @@ queue_base <- R6::R6Class(
     ##'
     ##' @param name Optional name for a created bundle
     ##'
-    ##' @param depends_on Optional task ids to depend on.
-    ##'   Should be a list of lists with an element per task.
-    ##'   For example, list(list("abcde", "12345"), list(), list("12345"))
+    ##' @param depends_on Optional task ids to depend on (see
+    ##'   [context::bulk_task_save()]).
     ##'
     ##' @param overwrite Logical, indicating if we should overwrite any
     ##'   bundle that exists with name `name`.
@@ -292,10 +291,8 @@ queue_base <- R6::R6Class(
     ##' @param overwrite Logical, indicating if we should overwrite any
     ##'   bundle that exists with name `name`.
     ##'
-    ##' @param depends_on Optional task ids to depend on.
-    ##'   Should be a list of lists with an element per task.
-    ##'   For example, list(list("abcde", "12345"), list(), list("12345"))
-    ##'
+    ##' @param depends_on Optional task ids to depend on (see
+    ##'   [context::bulk_task_save()]).
     lapply = function(X, FUN, ..., envir = parent.frame(),
                       timeout = 0, time_poll = 1, progress = NULL,
                       name = NULL, overwrite = FALSE, depends_on = NULL) {
@@ -345,10 +342,8 @@ queue_base <- R6::R6Class(
     ##'
     ##' @param use_names Use names
     ##'
-    ##' @param depends_on Optional task ids to depend on.
-    ##'   Should be a list of lists with an element per task.
-    ##'   For example, list(list("abcde", "12345"), list(), list("12345"))
-    ##'
+    ##' @param depends_on Optional task ids to depend on (see
+    ##'   [context::bulk_task_save()]).
     mapply = function(FUN, ..., MoreArgs = NULL,
                       envir = parent.frame(), timeout = 0,
                       time_poll = 1, progress = NULL, name = NULL,

--- a/R/queue_base.R
+++ b/R/queue_base.R
@@ -292,7 +292,9 @@ queue_base <- R6::R6Class(
     ##' @param overwrite Logical, indicating if we should overwrite any
     ##'   bundle that exists with name `name`.
     ##'
-    ##' @param depends_on Optional vector of task ids to depend on.
+    ##' @param depends_on Optional task ids to depend on.
+    ##'   Should be a list of lists with an element per task.
+    ##'   For example, list(list("abcde", "12345"), list(), list("12345"))
     ##'
     lapply = function(X, FUN, ..., envir = parent.frame(),
                       timeout = 0, time_poll = 1, progress = NULL,
@@ -343,7 +345,9 @@ queue_base <- R6::R6Class(
     ##'
     ##' @param use_names Use names
     ##'
-    ##' @param depends_on Optional vector of task ids to depend on
+    ##' @param depends_on Optional task ids to depend on.
+    ##'   Should be a list of lists with an element per task.
+    ##'   For example, list(list("abcde", "12345"), list(), list("12345"))
     ##'
     mapply = function(FUN, ..., MoreArgs = NULL,
                       envir = parent.frame(), timeout = 0,

--- a/R/queue_base.R
+++ b/R/queue_base.R
@@ -180,7 +180,7 @@ queue_base <- R6::R6Class(
     ##'
     ##' @param submit Logical indicating if the task should be submitted
     ##'
-    ##' @param depends_on Optional vector of task dependencies
+    ##' @param depends_on Optional vector of task ids to depend on
     ##'
     ##' @param name Optional name for the task
     enqueue = function(expr, envir = parent.frame(), submit = TRUE,
@@ -202,7 +202,7 @@ queue_base <- R6::R6Class(
     ##'
     ##' @param name Optional name for the task
     ##'
-    ##' @param depends_on Optional vector of task dependencies
+    ##' @param depends_on Optional vector of task ids to depend on
     ##'
     enqueue_ = function(expr, envir = parent.frame(), submit = TRUE,
                         name = NULL, depends_on = NULL) {
@@ -250,7 +250,7 @@ queue_base <- R6::R6Class(
     ##'
     ##' @param name Optional name for a created bundle
     ##'
-    ##' @param depends_on Optional vector of task dependencies
+    ##' @param depends_on Optional vector of task ids to depend on
     ##'
     ##' @param overwrite Logical, indicating if we should overwrite any
     ##'   bundle that exists with name `name`.
@@ -289,12 +289,15 @@ queue_base <- R6::R6Class(
     ##'
     ##' @param overwrite Logical, indicating if we should overwrite any
     ##'   bundle that exists with name `name`.
+    ##'
+    ##' @param depends_on Optional vector of task ids to depend on.
+    ##'
     lapply = function(X, FUN, ..., envir = parent.frame(),
                       timeout = 0, time_poll = 1, progress = NULL,
-                      name = NULL, overwrite = FALSE) {
+                      name = NULL, overwrite = FALSE, depends_on = NULL) {
       qlapply(self, private, X, FUN, ..., envir = envir,
               timeout = timeout, time_poll = time_poll,
-              progress = progress, name = name, overwrite = overwrite)
+              progress = progress, name = name, overwrite = overwrite, depends_on = depends_on)
     },
 
     ##' @description A wrapper like `mapply`
@@ -337,17 +340,20 @@ queue_base <- R6::R6Class(
     ##'   bundle that exists with name `name`.
     ##'
     ##' @param use_names Use names
+    ##'
+    ##' @param depends_on Optional vector of task ids to depend on
+    ##'
     mapply = function(FUN, ..., MoreArgs = NULL,
                       envir = parent.frame(), timeout = 0,
                       time_poll = 1, progress = NULL, name = NULL,
-                      use_names = TRUE, overwrite = FALSE) {
+                      use_names = TRUE, overwrite = FALSE, depends_on = NULL) {
       ## TODO: consider deleting
       X <- mapply_X(...)
       self$enqueue_bulk(X, FUN, DOTS = MoreArgs, do_call = TRUE,
                         envir = envir, timeout = timeout,
                         time_poll = time_poll, progress = progress,
                         name = name, use_names = use_names,
-                        overwrite = overwrite)
+                        overwrite = overwrite, depends_on = depends_on)
     },
 
     ##' @description Submit a task into a queue. This is a stub
@@ -358,7 +364,7 @@ queue_base <- R6::R6Class(
     ##'
     ##' @param names Optional vector of names of tasks
     ##'
-    ##' @param depends_on Optional vector of task dependencies, named by task id
+    ##' @param depends_on Optional vector of task ids to depend on, named by task id
     submit = function(task_ids, names = NULL, depends_on = NULL) {
     },
 

--- a/R/queue_base.R
+++ b/R/queue_base.R
@@ -180,6 +180,8 @@ queue_base <- R6::R6Class(
     ##'
     ##' @param submit Logical indicating if the task should be submitted
     ##'
+    ##' @param depends_on Optional vector of task dependencies
+    ##'
     ##' @param name Optional name for the task
     enqueue = function(expr, envir = parent.frame(), submit = TRUE,
                        name = NULL, depends_on = NULL) {
@@ -199,6 +201,9 @@ queue_base <- R6::R6Class(
     ##' @param submit Logical indicating if the task should be submitted
     ##'
     ##' @param name Optional name for the task
+    ##'
+    ##' @param names Optional vector of task dependencies
+    ##'
     enqueue_ = function(expr, envir = parent.frame(), submit = TRUE,
                         name = NULL, depends_on = NULL) {
       self$initialize_context()
@@ -245,15 +250,17 @@ queue_base <- R6::R6Class(
     ##'
     ##' @param name Optional name for a created bundle
     ##'
+    ##' @param depends_on Optional vector of task dependencies
+    ##'
     ##' @param overwrite Logical, indicating if we should overwrite any
     ##'   bundle that exists with name `name`.
     enqueue_bulk = function(X, FUN, ..., do_call = TRUE,
                             envir = parent.frame(),
                             timeout = 0, time_poll = 1, progress = NULL,
-                            name = NULL, overwrite = FALSE) {
+                            name = NULL, overwrite = FALSE, depends_on = NULL) {
       enqueue_bulk(self, private, X, FUN, ..., do_call = do_call, envir = envir,
                    timeout = timeout, time_poll = time_poll,
-                   progress = progress, name = name, overwrite = overwrite)
+                   progress = progress, name = name, overwrite = overwrite, depends_on = depends_on)
     },
 
     ##' @description Apply a function over a list of data. This is
@@ -351,7 +358,7 @@ queue_base <- R6::R6Class(
     ##'
     ##' @param names Optional vector of names of tasks
     ##'
-    ##' @param names Optional vector of task dependencies, named by task id
+    ##' @param depends_on Optional vector of task dependencies, named by task id
     submit = function(task_ids, names = NULL, depends_on = NULL) {
     },
 

--- a/R/queue_local.R
+++ b/R/queue_local.R
@@ -111,7 +111,7 @@ queue_local <- R6::R6Class(
 
     ## Ordinarily there would be two objects created; one worker and
     ## one queue.  but for the local queue these are the same.
-    submit = function(task_ids, names = NULL) {
+    submit = function(task_ids, names = NULL, depends_on = NULL) {
       if (!is.null(self$log_path)) {
         private$db$mset(task_ids, self$log_path, "log_path")
       }

--- a/man/queue_base.Rd
+++ b/man/queue_base.Rd
@@ -295,7 +295,7 @@ the value of \code{a} to the worker along with the expression.}
 
 \item{\code{name}}{Optional name for the task}
 
-\item{\code{depends_on}}{Optional vector of task dependencies}
+\item{\code{depends_on}}{Optional vector of task ids to depend on}
 }
 \if{html}{\out{</div>}}
 }
@@ -329,7 +329,7 @@ the value of \code{a} to the worker along with the expression.}
 
 \item{\code{name}}{Optional name for the task}
 
-\item{\code{depends_on}}{Optional vector of task dependencies}
+\item{\code{depends_on}}{Optional vector of task ids to depend on}
 }
 \if{html}{\out{</div>}}
 }
@@ -393,7 +393,7 @@ progress bar if in an interactive session.}
 \item{\code{overwrite}}{Logical, indicating if we should overwrite any
 bundle that exists with name \code{name}.}
 
-\item{\code{depends_on}}{Optional vector of task dependencies}
+\item{\code{depends_on}}{Optional vector of task ids to depend on}
 }
 \if{html}{\out{</div>}}
 }
@@ -414,7 +414,8 @@ equivalent to using \verb{$enqueue()} over each element in the list.
   time_poll = 1,
   progress = NULL,
   name = NULL,
-  overwrite = FALSE
+  overwrite = FALSE,
+  depends_on = NULL
 )}\if{html}{\out{</div>}}
 }
 
@@ -444,6 +445,8 @@ progress bar if in an interactive session.}
 
 \item{\code{overwrite}}{Logical, indicating if we should overwrite any
 bundle that exists with name \code{name}.}
+
+\item{\code{depends_on}}{Optional vector of task ids to depend on.}
 }
 \if{html}{\out{</div>}}
 }
@@ -531,7 +534,7 @@ to do anything.
 
 \item{\code{names}}{Optional vector of names of tasks}
 
-\item{\code{depends_on}}{Optional vector of task dependencies, named by task id}
+\item{\code{depends_on}}{Optional vector of task ids to depend on, named by task id}
 }
 \if{html}{\out{</div>}}
 }

--- a/man/queue_base.Rd
+++ b/man/queue_base.Rd
@@ -475,7 +475,8 @@ should feel intuitive.
   progress = NULL,
   name = NULL,
   use_names = TRUE,
-  overwrite = FALSE
+  overwrite = FALSE,
+  depends_on = NULL
 )}\if{html}{\out{</div>}}
 }
 
@@ -509,6 +510,8 @@ progress bar if in an interactive session.}
 \item{\code{overwrite}}{Logical, indicating if we should overwrite any
 bundle that exists with name \code{name}.}
 
+\item{\code{depends_on}}{Optional vector of task ids to depend on}
+
 \item{\code{X}}{Typically a \link{data.frame}, which you want to apply \code{FUN}
 over, row-wise. The names of the \code{data.frame} must match the
 arguments of your function.}
@@ -534,7 +537,8 @@ to do anything.
 
 \item{\code{names}}{Optional vector of names of tasks}
 
-\item{\code{depends_on}}{Optional vector of task ids to depend on, named by task id}
+\item{\code{depends_on}}{Optional named list of task ids to vectors of
+dependencies, e.g. list("t3" = c("t", "t1"), "t4" = "t)}
 }
 \if{html}{\out{</div>}}
 }

--- a/man/queue_base.Rd
+++ b/man/queue_base.Rd
@@ -448,7 +448,9 @@ progress bar if in an interactive session.}
 \item{\code{overwrite}}{Logical, indicating if we should overwrite any
 bundle that exists with name \code{name}.}
 
-\item{\code{depends_on}}{Optional vector of task ids to depend on.}
+\item{\code{depends_on}}{Optional task ids to depend on.
+Should be a list of lists with an element per task.
+For example, list(list("abcde", "12345"), list(), list("12345"))}
 }
 \if{html}{\out{</div>}}
 }
@@ -512,7 +514,9 @@ progress bar if in an interactive session.}
 \item{\code{overwrite}}{Logical, indicating if we should overwrite any
 bundle that exists with name \code{name}.}
 
-\item{\code{depends_on}}{Optional vector of task ids to depend on}
+\item{\code{depends_on}}{Optional task ids to depend on.
+Should be a list of lists with an element per task.
+For example, list(list("abcde", "12345"), list(), list("12345"))}
 
 \item{\code{X}}{Typically a \link{data.frame}, which you want to apply \code{FUN}
 over, row-wise. The names of the \code{data.frame} must match the

--- a/man/queue_base.Rd
+++ b/man/queue_base.Rd
@@ -393,7 +393,9 @@ progress bar if in an interactive session.}
 \item{\code{overwrite}}{Logical, indicating if we should overwrite any
 bundle that exists with name \code{name}.}
 
-\item{\code{depends_on}}{Optional vector of task ids to depend on}
+\item{\code{depends_on}}{Optional task ids to depend on.
+Should be a list of lists with an element per task.
+For example, list(list("abcde", "12345"), list(), list("12345"))}
 }
 \if{html}{\out{</div>}}
 }

--- a/man/queue_base.Rd
+++ b/man/queue_base.Rd
@@ -26,6 +26,7 @@ actually submitting tasks.
 \item \href{#method-queue_base-task_get}{\code{queue_base$task_get()}}
 \item \href{#method-queue_base-task_result}{\code{queue_base$task_result()}}
 \item \href{#method-queue_base-task_delete}{\code{queue_base$task_delete()}}
+\item \href{#method-queue_base-task_retry_failed}{\code{queue_base$task_retry_failed()}}
 \item \href{#method-queue_base-task_bundle_list}{\code{queue_base$task_bundle_list()}}
 \item \href{#method-queue_base-task_bundle_info}{\code{queue_base$task_bundle_info()}}
 \item \href{#method-queue_base-task_bundle_get}{\code{queue_base$task_bundle_get()}}
@@ -191,6 +192,24 @@ hexadecimal string)}
 }
 }
 \if{html}{\out{<hr>}}
+\if{html}{\out{<a id="method-queue_base-task_retry_failed"></a>}}
+\if{latex}{\out{\hypertarget{method-queue_base-task_retry_failed}{}}}
+\subsection{Method \code{task_retry_failed()}}{
+Retry failed tasks
+\subsection{Usage}{
+\if{html}{\out{<div class="r">}}\preformatted{queue_base$task_retry_failed(task_ids)}\if{html}{\out{</div>}}
+}
+
+\subsection{Arguments}{
+\if{html}{\out{<div class="arguments">}}
+\describe{
+\item{\code{task_ids}}{A vector of task identifiers (each a
+hexadecimal string)}
+}
+\if{html}{\out{</div>}}
+}
+}
+\if{html}{\out{<hr>}}
 \if{html}{\out{<a id="method-queue_base-task_bundle_list"></a>}}
 \if{latex}{\out{\hypertarget{method-queue_base-task_bundle_list}{}}}
 \subsection{Method \code{task_bundle_list()}}{
@@ -253,7 +272,13 @@ Retry failed tasks in a bundle
 \subsection{Method \code{enqueue()}}{
 Queue a task
 \subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{queue_base$enqueue(expr, envir = parent.frame(), submit = TRUE, name = NULL)}\if{html}{\out{</div>}}
+\if{html}{\out{<div class="r">}}\preformatted{queue_base$enqueue(
+  expr,
+  envir = parent.frame(),
+  submit = TRUE,
+  name = NULL,
+  depends_on = NULL
+)}\if{html}{\out{</div>}}
 }
 
 \subsection{Arguments}{
@@ -269,6 +294,8 @@ the value of \code{a} to the worker along with the expression.}
 \item{\code{submit}}{Logical indicating if the task should be submitted}
 
 \item{\code{name}}{Optional name for the task}
+
+\item{\code{depends_on}}{Optional vector of task dependencies}
 }
 \if{html}{\out{</div>}}
 }
@@ -279,7 +306,13 @@ the value of \code{a} to the worker along with the expression.}
 \subsection{Method \code{enqueue_()}}{
 Queue a task
 \subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{queue_base$enqueue_(expr, envir = parent.frame(), submit = TRUE, name = NULL)}\if{html}{\out{</div>}}
+\if{html}{\out{<div class="r">}}\preformatted{queue_base$enqueue_(
+  expr,
+  envir = parent.frame(),
+  submit = TRUE,
+  name = NULL,
+  depends_on = NULL
+)}\if{html}{\out{</div>}}
 }
 
 \subsection{Arguments}{
@@ -295,6 +328,8 @@ the value of \code{a} to the worker along with the expression.}
 \item{\code{submit}}{Logical indicating if the task should be submitted}
 
 \item{\code{name}}{Optional name for the task}
+
+\item{\code{depends_on}}{Optional vector of task dependencies}
 }
 \if{html}{\out{</div>}}
 }
@@ -320,7 +355,8 @@ should feel intuitive.
   time_poll = 1,
   progress = NULL,
   name = NULL,
-  overwrite = FALSE
+  overwrite = FALSE,
+  depends_on = NULL
 )}\if{html}{\out{</div>}}
 }
 
@@ -356,6 +392,8 @@ progress bar if in an interactive session.}
 
 \item{\code{overwrite}}{Logical, indicating if we should overwrite any
 bundle that exists with name \code{name}.}
+
+\item{\code{depends_on}}{Optional vector of task dependencies}
 }
 \if{html}{\out{</div>}}
 }
@@ -483,7 +521,7 @@ Submit a task into a queue. This is a stub
 method and must be overridden by a derived class for the queue
 to do anything.
 \subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{queue_base$submit(task_ids, names = NULL)}\if{html}{\out{</div>}}
+\if{html}{\out{<div class="r">}}\preformatted{queue_base$submit(task_ids, names = NULL, depends_on = NULL)}\if{html}{\out{</div>}}
 }
 
 \subsection{Arguments}{
@@ -492,6 +530,8 @@ to do anything.
 \item{\code{task_ids}}{Vector of tasks to submit}
 
 \item{\code{names}}{Optional vector of names of tasks}
+
+\item{\code{depends_on}}{Optional vector of task dependencies, named by task id}
 }
 \if{html}{\out{</div>}}
 }

--- a/man/queue_base.Rd
+++ b/man/queue_base.Rd
@@ -393,9 +393,8 @@ progress bar if in an interactive session.}
 \item{\code{overwrite}}{Logical, indicating if we should overwrite any
 bundle that exists with name \code{name}.}
 
-\item{\code{depends_on}}{Optional task ids to depend on.
-Should be a list of lists with an element per task.
-For example, list(list("abcde", "12345"), list(), list("12345"))}
+\item{\code{depends_on}}{Optional task ids to depend on (see
+\code{\link[context:bulk_task_save]{context::bulk_task_save()}}).}
 }
 \if{html}{\out{</div>}}
 }
@@ -448,9 +447,8 @@ progress bar if in an interactive session.}
 \item{\code{overwrite}}{Logical, indicating if we should overwrite any
 bundle that exists with name \code{name}.}
 
-\item{\code{depends_on}}{Optional task ids to depend on.
-Should be a list of lists with an element per task.
-For example, list(list("abcde", "12345"), list(), list("12345"))}
+\item{\code{depends_on}}{Optional task ids to depend on (see
+\code{\link[context:bulk_task_save]{context::bulk_task_save()}}).}
 }
 \if{html}{\out{</div>}}
 }
@@ -514,9 +512,8 @@ progress bar if in an interactive session.}
 \item{\code{overwrite}}{Logical, indicating if we should overwrite any
 bundle that exists with name \code{name}.}
 
-\item{\code{depends_on}}{Optional task ids to depend on.
-Should be a list of lists with an element per task.
-For example, list(list("abcde", "12345"), list(), list("12345"))}
+\item{\code{depends_on}}{Optional task ids to depend on (see
+\code{\link[context:bulk_task_save]{context::bulk_task_save()}}).}
 
 \item{\code{X}}{Typically a \link{data.frame}, which you want to apply \code{FUN}
 over, row-wise. The names of the \code{data.frame} must match the

--- a/tests/testthat/test-bulk.R
+++ b/tests/testthat/test-bulk.R
@@ -89,11 +89,14 @@ test_that("enqueue_bulk with dependencies", {
   expect_error(obj$enqueue_bulk(1:3, quote(I), depends_on = "123"),
                "Failed to save as dependency 123 does not exist")
 
-  t2 <- obj$enqueue_bulk(1:3, quote(I), depends_on = t$id)
-  t3 <- obj$enqueue_bulk(1:3, quote(I), depends_on = c(t$id, t2$id))
+  expect_error(obj$enqueue_bulk(1:3, quote(I), depends_on = t$id),
+               "Failed to save as 'depends_on' must be of length 3")
+
+  t2 <- obj$enqueue_bulk(1:3, quote(I), depends_on = rep(t$id, 3))
+  t3 <- obj$enqueue_bulk(1:3, quote(I), depends_on = list(t$id, t2$id, list(t$id, t2$id)))
 
   expect_equal(context::task_deps(t2$ids, ctx), rep(list(t$id), 3))
-  expect_equal(context::task_deps(t3$ids, ctx), rep(list(c(t$id, t2$id)), 3))
+  expect_equal(context::task_deps(t3$ids, ctx), list(t$id, t2$id, list(t$id, t2$id)))
 })
 
 test_that("exotic functions", {

--- a/tests/testthat/test-bulk.R
+++ b/tests/testthat/test-bulk.R
@@ -89,10 +89,10 @@ test_that("enqueue_bulk with dependencies", {
   expect_error(obj$enqueue_bulk(1:3, quote(I), depends_on = "123"),
                "Failed to save as dependency 123 does not exist")
 
-  expect_error(obj$enqueue_bulk(1:3, quote(I), depends_on = t$id),
-               "Failed to save as 'depends_on' must be of length 3")
+  expect_error(obj$enqueue_bulk(1:3, quote(I), depends_on = list(t$id)),
+               "'depends_on' must either be a vector or a list of length 3")
 
-  t2 <- obj$enqueue_bulk(1:3, quote(I), depends_on = rep(t$id, 3))
+  t2 <- obj$enqueue_bulk(1:3, quote(I), depends_on = t$id)
   t3 <- obj$enqueue_bulk(1:3, quote(I), depends_on = list(t$id, t2$id, list(t$id, t2$id)))
 
   expect_equal(context::task_deps(t2$ids, ctx), rep(list(t$id), 3))

--- a/tests/testthat/test-queue-base.R
+++ b/tests/testthat/test-queue-base.R
@@ -43,6 +43,22 @@ test_that("enqueue", {
   expect_equal(t$result(), sin(1))
 })
 
+test_that("enqueue with dependencies", {
+  ctx <- context::context_save(tempfile(), storage_type = "environment")
+  ctx <- context::context_load(ctx, new.env(parent = .GlobalEnv))
+  obj <- queue_base$new(ctx)
+  t <- obj$enqueue(sin(1))
+
+  expect_error(obj$enqueue(sin(1), depends_on = "123"),
+               "Failed to save as dependency 123 does not exist")
+
+  t2 <- obj$enqueue(sin(1), depends_on = t$id)
+  t3 <- obj$enqueue(sin(1), depends_on = c(t$id, t2$id))
+  expect_equal(t$status(), "PENDING")
+  expect_equal(t2$status(), "PENDING")
+  expect_equal(t3$status(), "PENDING")
+})
+
 test_that("create by id", {
   ctx <- context::context_save(tempfile(), storage_type = "environment")
   obj <- queue_base$new(ctx$id, ctx$root)

--- a/tests/testthat/test-queue-base.R
+++ b/tests/testthat/test-queue-base.R
@@ -54,9 +54,9 @@ test_that("enqueue with dependencies", {
 
   t2 <- obj$enqueue(sin(1), depends_on = t$id)
   t3 <- obj$enqueue(sin(1), depends_on = c(t$id, t2$id))
-  expect_equal(t$status(), "PENDING")
-  expect_equal(t2$status(), "PENDING")
-  expect_equal(t3$status(), "PENDING")
+
+  expect_equal(context::task_deps(t2$id, ctx), list(t$id))
+  expect_equal(context::task_deps(t3$id, ctx), list(c(t$id, t2$id)))
 })
 
 test_that("create by id", {


### PR DESCRIPTION
Allows single or bulk enqueuing to accept a vector or list of task ids to depend on. Requires https://github.com/mrc-ide/context/pull/21